### PR TITLE
fix variable matching with census data

### DIFF
--- a/Census Data Import Cecil County.R
+++ b/Census Data Import Cecil County.R
@@ -1,6 +1,9 @@
 library(tidyverse)
 library(tidycensus)
 
+Sys.getenv("CENSUS_API_KEY") #census_api_key("CENSUS_API_KEY",install=TRUE)
+# census_api_key("CENSUS_API_KEY")
+
 #choose our variables
 var = load_variables(2019,"acs5",cache=TRUE) 
 
@@ -22,13 +25,12 @@ vars = var %>% dplyr::filter(grepl("B08006", name)) %>%
 
 #import Cecil County
 
-census_api_key("bb637a985d9b9b2dcdf2ea179ed31ae79eb077b0")
-
-df = get_acs(geography="county", state = "MD",variables = vars %>% select(name) %>% unlist(),year=2019)
+df = get_acs(geography="county", state = "MD",variables = vars %>% select(name) %>% unlist() %>% unname(),year=2019,keep_geo_vars=TRUE)
 
 #Name is what changes one dataset from another.
 
 df2 = df %>% dplyr::filter(NAME == "Cecil County, Maryland") %>% 
-  cbind(vars)
+  left_join(vars,by=c("variable"="name"))
+  #cbind(vars) - this method doesn't work because get_acs() may change the order on return
 
 df2 %>% write_csv(file = "Cecil_County_Census_Data.csv")

--- a/Census Data Import Harford County.R
+++ b/Census Data Import Harford County.R
@@ -5,6 +5,9 @@
 library(tidyverse)
 library(tidycensus)
 
+Sys.getenv("CENSUS_API_KEY") #census_api_key("CENSUS_API_KEY",install=TRUE)
+# census_api_key("CENSUS_API_KEY")
+
 #choose our variables
 var = load_variables(2019,"acs5",cache=TRUE) 
 
@@ -26,12 +29,11 @@ vars = var %>% dplyr::filter(grepl("B08006", name)) %>%
 
 #import Harford County
 
-census_api_key("bb637a985d9b9b2dcdf2ea179ed31ae79eb077b0")
-
-df = get_acs(geography="county", state = "MD",variables = vars %>% select(name) %>% unlist(),year=2019)
+df = get_acs(geography="county", state = "MD",variables = vars %>% select(name) %>% unlist() %>% unname(),year=2019,keep_geo_vars=TRUE)
 
 df2 = df %>% dplyr::filter(NAME == "Harford County, Maryland") %>% 
-  cbind(vars)
+  left_join(vars,by=c("variable"="name"))
+  #cbind(vars) - this method doesn't work because get_acs() may change the order on return
 
 df2 %>% write_csv(file = "Harford_County_Census_Data.csv")
 

--- a/Combining Harford and Cecil data.R
+++ b/Combining Harford and Cecil data.R
@@ -4,6 +4,9 @@ library(tidyverse)
 library(tidycensus)
 library(plyr)
 
+Sys.getenv("CENSUS_API_KEY") #census_api_key("CENSUS_API_KEY",install=TRUE)
+# census_api_key("CENSUS_API_KEY")
+
 var = load_variables(2019,"acs5",cache=TRUE) 
 
 #B08006_008 _ public transportation
@@ -21,21 +24,18 @@ vars = var %>% dplyr::filter(grepl("B08006", name)) %>%
   rbind(var %>% dplyr::filter(grepl("B08141", name))) %>%
   rbind(var %>% dplyr::filter(grepl("B25044", name))) 
 
-
-census_api_key("bb637a985d9b9b2dcdf2ea179ed31ae79eb077b0")
-
-df = get_acs(geography="county", state = "MD",variables = vars %>% select(name) %>% unlist(),year=2019)
+df = get_acs(geography="county", state = "MD",variables = vars %>% select(name) %>% unlist() %>% unname(),year=2019,keep_geo_vars=TRUE)
 
 cecil_df = df %>% dplyr::filter(NAME == "Cecil County, Maryland") %>% 
-  cbind(vars) %>% select(NAME, concept, name, label, estimate, moe)
+  left_join(vars,by=c("variable"="name")) %>% select(NAME, concept, variable, label, estimate, moe)
 
 harford_df = df %>% dplyr::filter(NAME == "Harford County, Maryland") %>% 
-  cbind(vars) %>% select(NAME, name, estimate, moe)
+  left_join(vars,by=c("variable"="name")) %>% select(NAME, variable, estimate, moe)
 
 baltimore_df = df %>% dplyr::filter(NAME == "Baltimore County, Maryland") %>% 
-  cbind(vars) %>% select(NAME, name, estimate, moe)
+  left_join(vars,by=c("variable"="name")) %>% select(NAME, variable, estimate, moe)
 
-ult_df = cecil_df %>% left_join(harford_df,by= "name")
+ult_df = cecil_df %>% left_join(harford_df,by= "variable")
 
 ult_df = ult_df %>% rename(
   "cecil_moe" = "moe.x",
@@ -59,18 +59,30 @@ ult_df = ult_df %>% mutate(diff = cecil_estimate - harford_estimate)
 
 #Estimate!!Total: (vehicles)
 
-#harford_dff = harford_df %>% select(-moe) %>% pivot_wider(names_from = "name", values_from = "estimate") %>% rbind(cecil_df %>% select(-c(moe, concept, label)) %>% pivot_wider(names_from = "name", values_from = "estimate"))
+#harford_dff = harford_df %>% select(-moe) %>% pivot_wider(names_from = "variable", values_from = "estimate") %>% rbind(cecil_df %>% select(-c(moe, concept, label)) %>% pivot_wider(names_from = "variable", values_from = "estimate"))
 
-#harford_df %>% select(-moe) %>% pivot_wider(names_from = "name", values_from = "estimate") %>% plyr::rbind.fill(cecil_df %>% select(-moe) %>% pivot_wider(names_from = "name", values_from = "estimate"))
-harford_dff = harford_df %>% select(-moe) %>% pivot_wider(names_from = "name", values_from = "estimate") %>% rbind(cecil_df %>% select(-c(moe, concept, label)) %>% pivot_wider(names_from = "name", values_from = "estimate")) %>% rbind(baltimore_df %>% select(-c(moe)) %>% pivot_wider(names_from = "name", values_from = "estimate"))
+#harford_df %>% select(-moe) %>% pivot_wider(names_from = "variable", values_from = "estimate") %>% plyr::rbind.fill(cecil_df %>% select(-moe) %>% pivot_wider(names_from = "variable", values_from = "estimate"))
+harford_dff = harford_df %>% select(-moe) %>% pivot_wider(names_from = "variable", values_from = "estimate") %>% rbind(cecil_df %>% select(-c(moe, concept, label)) %>% pivot_wider(names_from = "variable", values_from = "estimate")) %>% rbind(baltimore_df %>% select(-c(moe)) %>% pivot_wider(names_from = "variable", values_from = "estimate"))
 
 
+# model
 model = lm(data = harford_dff, formula = B08203_001~ B08203_027)
-
 summary(model)
 
+# write new column based on model
+harford_dff$predict = predict(model)
+
+# example plot
+harford_dff %>%
+ggplot() +
+  geom_point(aes(x=B08203_027,y=B08203_001),colour="red") +
+  geom_line(data=,aes(x=B08203_027,y=predict),size=1,alpha=0.3,colour="blue") +
+  theme_bw()
+plot(data=harford_dff,x=B08203_027,y=B08203_001)
+abline(model)
+
 #11-17
-#get data to be not messed up
+#get data to be not messed up (done)
 #pull in ALL counties
 #select features; in depth analysis; ask questions
 #add own features (for further future)


### PR DESCRIPTION
As discussed, note the following changes:
- cleanup census data pull (we should have an environmental variable do the work, not use the api key in the script - see the comment after in how to save the environment variable locally)
- fix census matching
   - add `unname()` in what's passed to `get_acs()`'s `variables` parameter - this allows us to get back the variable passed correctly
   - add`keep_geo_vars=TRUE` parameter to `get_acs()` - this allows the variables passed to be returned as a new column "variable"
   - match using `left_join()` instead of `cbind()` - this prevents mismatch
   - rename "name" to "variable" throughout the script (since the column's name changed)
- see `ggplot()` after the `lm()` model and how we can graph the output of the linear model (read: linear regression) against the original dataset of 3 counties: Harford, Cecil, Baltimore